### PR TITLE
Remove duplicate border in drag-and-drop component

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,17 +14,7 @@
                 <h2 class="card-title">Document to Markdown Converter</h2>
                 
                 <!-- Drag and Drop Zone -->
-                <div id="dropZone" class="border-4 border-dashed border-base-300 rounded-lg p-8 text-center cursor-pointer hover:border-primary transition-colors">
-                    <div class="flex flex-col items-center gap-4">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-                        </svg>
-                        <div>
-                            <p class="text-lg font-semibold">Drag and drop files here</p>
-                            <p class="text-sm text-base-content/70">or click to select files</p>
-                        </div>
-                    </div>
-                </div>
+                <div id="dropZone"></div>
 
                 <!-- File Input (Hidden) -->
                 <input type="file" id="fileInput" class="hidden" accept="image/*,.pdf,.doc,.docx,.txt" multiple>


### PR DESCRIPTION
This PR fixes the visual issue where the drag-and-drop component had two dashed borders. The fix removes the border styling from the HTML file since the component should be self-contained and manage its own styling through the FileDropZone class.