### PR TITLE
Update server configurations for external access

### DIFF
--- a/.openhands_instructions
+++ b/.openhands_instructions
@@ -18,10 +18,10 @@ npm install
 
 3. Start development server:
 ```bash
-cd src && python3 -m http.server 8000
+cd src && python3 -m http.server 8000 --bind 0.0.0.0
 ```
 
-The frontend will be available at http://localhost:8000/index.html
+The frontend will be available at http://0.0.0.0:8000/index.html (or your machine's IP address)
 
 ### Backend
 1. Navigate to backend directory:
@@ -36,10 +36,10 @@ pip install -r requirements.txt
 
 3. Start development server:
 ```bash
-uvicorn src.main:app --reload --port 8001
+uvicorn app.main:app --reload --port 8001 --host 0.0.0.0
 ```
 
-The API will be available at http://localhost:8001
+The API will be available at http://0.0.0.0:8001 (or your machine's IP address)
 
 ## Project Structure
 ```

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,9 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "Doc-to-Markdown API"
+    version: str = "0.1.0"
+    api_prefix: str = "/api/v1"
+    upload_dir: str = "/tmp/doc-to-markdown"
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,11 @@
+from fastapi import FastAPI
+from .config import settings
+
+app = FastAPI(
+    title=settings.app_name,
+    version=settings.version,
+)
+
+@app.get(f"{settings.api_prefix}/health")
+async def health_check():
+    return {"status": "healthy"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi>=0.104.1
+uvicorn>=0.24.0
+python-multipart>=0.0.6  # for file uploads
+docling>=2.14.0
+python-dotenv>=1.0.0
+pydantic>=2.5.2
+pytest>=7.4.3  # for testing


### PR DESCRIPTION
This PR updates the server configurations to allow access from outside WSL Ubuntu:

- Modified frontend server to bind to 0.0.0.0
- Modified backend server to use host 0.0.0.0
- Updated documentation to reflect these changes
- Added notes about using machine's IP address for access

After this change, both servers will be accessible from outside WSL Ubuntu using either:
- http://0.0.0.0:8000 (frontend)
- http://0.0.0.0:8001 (backend)
- Or replace 0.0.0.0 with your machine's IP address