### PR TITLE
Implement API endpoints for document conversion

### DIFF
--- a/backend/app/api/routes/convert.py
+++ b/backend/app/api/routes/convert.py
@@ -1,0 +1,44 @@
+import tempfile
+from pathlib import Path
+from fastapi import APIRouter, UploadFile, HTTPException
+from ...core.converter import DocumentConverter
+from ...schemas.documents import ConversionResponse, ErrorResponse
+
+router = APIRouter()
+
+@router.post(
+    "/convert",
+    response_model=ConversionResponse,
+    responses={
+        413: {"model": ErrorResponse, "description": "File too large"},
+        415: {"model": ErrorResponse, "description": "Unsupported file type"},
+        500: {"model": ErrorResponse, "description": "Internal server error"},
+    },
+    description="Convert an uploaded document to markdown format",
+)
+async def convert_document(file: UploadFile) -> ConversionResponse:
+    """
+    Convert an uploaded document to markdown format.
+    
+    Supports the following formats:
+    - PDF
+    - Images (JPEG, PNG, GIF, WebP)
+    - Microsoft Word (DOC, DOCX)
+    - HTML
+    - Microsoft PowerPoint (PPTX)
+    """
+    converter = DocumentConverter()
+    
+    # Create a temporary file to store the upload
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_path = Path(temp_file.name)
+        try:
+            result = await converter.convert(file, temp_path)
+            return ConversionResponse(**result)
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Error during document conversion: {str(e)}"
+            )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,34 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from .config import settings
+from .api.routes import convert
 
 app = FastAPI(
     title=settings.app_name,
     version=settings.version,
+    description="API for converting various document formats to markdown",
 )
 
-@app.get(f"{settings.api_prefix}/health")
+# Configure CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, replace with specific origins
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Add routers
+app.include_router(
+    convert.router,
+    prefix=f"{settings.api_prefix}/v1",
+    tags=["conversion"],
+)
+
+@app.get(
+    f"{settings.api_prefix}/health",
+    tags=["health"],
+    description="Check if the service is healthy",
+)
 async def health_check():
     return {"status": "healthy"}

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+class ConversionResponse(BaseModel):
+    content: str = Field(..., description="The converted markdown content")
+    metadata: dict = Field(..., description="Additional information about the conversion")
+
+class ErrorResponse(BaseModel):
+    detail: str = Field(..., description="Error message describing what went wrong")


### PR DESCRIPTION
This PR implements the API endpoints for document conversion as outlined in the backend implementation plan. Changes include:

- Added Pydantic models for request/response validation
- Implemented /api/v1/convert endpoint for document conversion
- Added proper error responses and documentation
- Added CORS middleware for frontend integration
- Updated main app to include the conversion router

The API now supports:
- File upload and conversion
- Multiple file formats (PDF, images, DOCX, HTML, PPTX)
- Proper error handling with status codes
- OpenAPI documentation