### PR TITLE
Add detailed logging to tests and disable cleanup

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,11 +1,16 @@
 import os
 import pytest
+import logging
 from pathlib import Path
 from fastapi.testclient import TestClient
 from PIL import Image
 from reportlab.pdfgen import canvas
 from io import BytesIO
 from app.main import app
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def test_client():
@@ -23,22 +28,32 @@ def fixtures_dir():
 def sample_pdf(fixtures_dir):
     """Create a sample PDF file for testing."""
     pdf_path = fixtures_dir / "sample.pdf"
+    logger.info(f"Creating sample PDF at: {pdf_path}")
+    
     if not pdf_path.exists():
         # Create a valid PDF file with some content
+        logger.info("Creating new PDF file with test content")
         c = canvas.Canvas(str(pdf_path))
         c.setFont("Helvetica", 12)
         c.drawString(100, 750, "Test PDF Document")
         c.drawString(100, 730, "This is a test document created for testing purposes.")
         c.drawString(100, 710, "It contains some text that should be converted to markdown.")
         c.save()
+        logger.info(f"PDF file created successfully, size: {pdf_path.stat().st_size} bytes")
+    else:
+        logger.info(f"Using existing PDF file, size: {pdf_path.stat().st_size} bytes")
+    
     return pdf_path
 
 @pytest.fixture
 def sample_image(fixtures_dir):
     """Create a sample PNG image for testing."""
     img_path = fixtures_dir / "sample.png"
+    logger.info(f"Creating sample PNG at: {img_path}")
+    
     if not img_path.exists():
         # Create a valid PNG image with some content
+        logger.info("Creating new PNG image with test content")
         img = Image.new('RGB', (200, 100), color='white')
         # Add some text to the image
         from PIL import ImageDraw
@@ -46,15 +61,18 @@ def sample_image(fixtures_dir):
         draw.text((10, 10), "Test Image", fill='black')
         draw.text((10, 30), "This is a test image", fill='black')
         img.save(img_path, format='PNG')
+        logger.info(f"PNG file created successfully, size: {img_path.stat().st_size} bytes")
+    else:
+        logger.info(f"Using existing PNG file, size: {img_path.stat().st_size} bytes")
+    
     return img_path
 
 @pytest.fixture
 def cleanup_fixtures(fixtures_dir):
-    """Clean up test files after tests."""
+    """Clean up test files after tests (disabled for debugging)."""
     yield
-    # Clean up any test files
+    # Cleanup disabled to allow inspection of test files
+    logger.info(f"Test files available in: {fixtures_dir}")
     for file in fixtures_dir.glob("*"):
         if file.is_file():
-            file.unlink()
-    if fixtures_dir.exists():
-        fixtures_dir.rmdir()
+            logger.info(f"  {file.name}: {file.stat().st_size} bytes")

--- a/backend/tests/core/test_converter.py
+++ b/backend/tests/core/test_converter.py
@@ -1,7 +1,12 @@
 import pytest
+import logging
 from pathlib import Path
 from fastapi import HTTPException, UploadFile
 from app.core.converter import DocumentConverter
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def converter():
@@ -44,10 +49,16 @@ def test_validate_file_type(converter):
 @pytest.mark.asyncio
 async def test_convert_pdf(converter, sample_pdf, tmp_path):
     """Test PDF conversion."""
+    logger.info(f"Testing PDF conversion with sample file: {sample_pdf}")
+    logger.info(f"Sample PDF exists: {sample_pdf.exists()}")
+    logger.info(f"Sample PDF size: {sample_pdf.stat().st_size} bytes")
+    
     # Create a mock UploadFile
     class MockUploadFile(UploadFile):
         async def read(self):
-            return open(sample_pdf, "rb").read()
+            content = open(sample_pdf, "rb").read()
+            logger.info(f"Read {len(content)} bytes from sample PDF")
+            return content
 
     upload_file = MockUploadFile(
         filename="test.pdf",
@@ -55,7 +66,15 @@ async def test_convert_pdf(converter, sample_pdf, tmp_path):
     )
 
     # Test conversion
-    result = await converter.convert(upload_file, tmp_path / "test.pdf")
+    save_path = tmp_path / "test.pdf"
+    logger.info(f"Converting PDF to: {save_path}")
+    result = await converter.convert(upload_file, save_path)
+    
+    logger.info("Conversion result metadata:")
+    logger.info(f"  Original file: {result.get('metadata', {}).get('original_file')}")
+    logger.info(f"  MIME type: {result.get('metadata', {}).get('mime_type')}")
+    logger.info(f"  Content length: {len(result.get('content', ''))}")
+    logger.info(f"  Content preview: {result.get('content', '')[:200]}")
     
     assert isinstance(result, dict)
     assert "content" in result
@@ -66,10 +85,16 @@ async def test_convert_pdf(converter, sample_pdf, tmp_path):
 @pytest.mark.asyncio
 async def test_convert_image(converter, sample_image, tmp_path):
     """Test image conversion."""
+    logger.info(f"Testing image conversion with sample file: {sample_image}")
+    logger.info(f"Sample image exists: {sample_image.exists()}")
+    logger.info(f"Sample image size: {sample_image.stat().st_size} bytes")
+    
     # Create a mock UploadFile
     class MockUploadFile(UploadFile):
         async def read(self):
-            return open(sample_image, "rb").read()
+            content = open(sample_image, "rb").read()
+            logger.info(f"Read {len(content)} bytes from sample image")
+            return content
 
     upload_file = MockUploadFile(
         filename="test.png",
@@ -77,7 +102,15 @@ async def test_convert_image(converter, sample_image, tmp_path):
     )
 
     # Test conversion
-    result = await converter.convert(upload_file, tmp_path / "test.png")
+    save_path = tmp_path / "test.png"
+    logger.info(f"Converting image to: {save_path}")
+    result = await converter.convert(upload_file, save_path)
+    
+    logger.info("Conversion result metadata:")
+    logger.info(f"  Original file: {result.get('metadata', {}).get('original_file')}")
+    logger.info(f"  MIME type: {result.get('metadata', {}).get('mime_type')}")
+    logger.info(f"  Content length: {len(result.get('content', ''))}")
+    logger.info(f"  Content preview: {result.get('content', '')[:200]}")
     
     assert isinstance(result, dict)
     assert "content" in result

--- a/backend/tests/core/test_docx_pipeline.py
+++ b/backend/tests/core/test_docx_pipeline.py
@@ -1,8 +1,13 @@
 import os
 import pytest
+import logging
 from docx import Document
 from docling.document_converter import DocumentConverter, WordFormatOption
 from docling.datamodel.base_models import InputFormat
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def test_docx_path(tmp_path):
@@ -66,31 +71,115 @@ def test_docx_basic_conversion(converter, test_docx_path):
 
 def test_docx_formatting(converter, test_docx_path):
     """Test that bold and italic formatting is preserved."""
+    logger.info(f"Testing DOCX formatting with file: {test_docx_path}")
+    logger.info(f"DOCX file exists: {os.path.exists(test_docx_path)}")
+    logger.info(f"DOCX file size: {os.path.getsize(test_docx_path)} bytes")
+    
     result = converter.convert(test_docx_path)
     markdown = result.document.export_to_markdown()
+    
+    logger.info("Generated markdown content:")
+    logger.info(markdown)
+    logger.info("\nChecking for bold and italic formatting...")
+    
+    # Check for bold text
+    if '**bold**' not in markdown:
+        logger.error("Could not find '**bold**' in markdown output")
+        logger.info("Found text fragments containing 'bold':")
+        for line in markdown.split('\n'):
+            if 'bold' in line:
+                logger.info(f"  {line}")
+    
+    # Check for italic text
+    if '*italic*' not in markdown:
+        logger.error("Could not find '*italic*' in markdown output")
+        logger.info("Found text fragments containing 'italic':")
+        for line in markdown.split('\n'):
+            if 'italic' in line:
+                logger.info(f"  {line}")
     
     assert '**bold**' in markdown
     assert '*italic*' in markdown
 
 def test_docx_lists(converter, test_docx_path):
     """Test that bullet and numbered lists are correctly converted."""
+    logger.info(f"Testing DOCX lists with file: {test_docx_path}")
+    
     result = converter.convert(test_docx_path)
     markdown = result.document.export_to_markdown()
     
+    logger.info("Generated markdown content:")
+    logger.info(markdown)
+    logger.info("\nChecking for bullet points and numbered lists...")
+    
     # Check bullet points
-    assert '* First bullet point' in markdown
-    assert '* Second bullet point' in markdown
+    if '* First bullet point' not in markdown:
+        logger.error("Could not find '* First bullet point' in markdown output")
+        logger.info("Found text fragments containing 'First bullet point':")
+        for line in markdown.split('\n'):
+            if 'First bullet point' in line:
+                logger.info(f"  {line}")
+    
+    if '* Second bullet point' not in markdown:
+        logger.error("Could not find '* Second bullet point' in markdown output")
+        logger.info("Found text fragments containing 'Second bullet point':")
+        for line in markdown.split('\n'):
+            if 'Second bullet point' in line:
+                logger.info(f"  {line}")
     
     # Check numbered list
+    if '1. First numbered item' not in markdown:
+        logger.error("Could not find '1. First numbered item' in markdown output")
+        logger.info("Found text fragments containing 'First numbered item':")
+        for line in markdown.split('\n'):
+            if 'First numbered item' in line:
+                logger.info(f"  {line}")
+    
+    if '2. Second numbered item' not in markdown:
+        logger.error("Could not find '2. Second numbered item' in markdown output")
+        logger.info("Found text fragments containing 'Second numbered item':")
+        for line in markdown.split('\n'):
+            if 'Second numbered item' in line:
+                logger.info(f"  {line}")
+    
+    assert '* First bullet point' in markdown
+    assert '* Second bullet point' in markdown
     assert '1. First numbered item' in markdown
     assert '2. Second numbered item' in markdown
 
 def test_docx_tables(converter, test_docx_path):
     """Test that tables are correctly converted to markdown format."""
+    logger.info(f"Testing DOCX tables with file: {test_docx_path}")
+    
     result = converter.convert(test_docx_path)
     markdown = result.document.export_to_markdown()
     
+    logger.info("Generated markdown content:")
+    logger.info(markdown)
+    logger.info("\nChecking for table formatting...")
+    
     # Check table headers and separator
+    if '| Header 1 | Header 2 |' not in markdown:
+        logger.error("Could not find '| Header 1 | Header 2 |' in markdown output")
+        logger.info("Found text fragments containing 'Header':")
+        for line in markdown.split('\n'):
+            if 'Header' in line:
+                logger.info(f"  {line}")
+    
+    if '|---|---|' not in markdown:
+        logger.error("Could not find table separator '|---|---|' in markdown output")
+        logger.info("Found lines containing '|':")
+        for line in markdown.split('\n'):
+            if '|' in line:
+                logger.info(f"  {line}")
+    
+    if '| Cell 1 | Cell 2 |' not in markdown:
+        logger.error("Could not find '| Cell 1 | Cell 2 |' in markdown output")
+        logger.info("Found text fragments containing 'Cell':")
+        for line in markdown.split('\n'):
+            if 'Cell' in line:
+                logger.info(f"  {line}")
+    
     assert '| Header 1 | Header 2 |' in markdown
     assert '|---|---|' in markdown
     assert '| Cell 1 | Cell 2 |' in markdown


### PR DESCRIPTION
This PR adds detailed logging to tests to help debug conversion issues:

1. Added detailed logging to test_converter.py for PDF and image conversion
2. Added detailed logging to test_docx_pipeline.py for DOCX formatting, lists and tables
3. Disabled test file cleanup to allow inspection of generated files

Current test failures:

1. PDF conversion: File is created but invalid (14 bytes)
2. Image conversion: File is created but invalid (66 bytes)
3. DOCX formatting: Markdown output does not contain expected bold/italic markers
4. DOCX lists: Markdown output does not contain expected list markers
5. DOCX tables: Markdown output has extra spaces in table formatting